### PR TITLE
Change default GBB flags to 0xA4B1

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,9 +208,9 @@
 				<i>Note that the following commands must be run as root.</i><br>
 				On modern versions of ChromeOS, you can use the <span class="codeinline">futility</span> tool to
 				set the GBB flags, for example:
-				<code>futility gbb -s --flash --flags=0x84b1</code>
+				<code>futility gbb -s --flash --flags=0xa4b1</code>
 				On older versions, there is a script you can call to set the GBB flags:
-				<code>/usr/share/vboot/bin/set_gbb_flags.sh 0x84b1</code>
+				<code>/usr/share/vboot/bin/set_gbb_flags.sh 0xa4b1</code>
 				<br>
 				Conversely, you can read the current GBB flags with the following command:
 				<code>futility gbb -g --flash --flags</code>


### PR DESCRIPTION
This enables `FORCE_UNLOCK_FASTBOOT`. This flag will likely be used on AluminiumOS-supported devices.